### PR TITLE
Add optional `name` to schema

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # mentioned account names will be requested for
 # review when someone opens a pull request.
-*   @msiuts @bemica @oppermax @cbrgm
+*   @msiuts @bemica @oppermax @cbrgm @VFUC

--- a/opensearch/resource_saved_objects.go
+++ b/opensearch/resource_saved_objects.go
@@ -57,6 +57,10 @@ func resourceSavedObjects() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,


### PR DESCRIPTION
Some references have a `name`. This is already supported in the underlying Go struct but was missed in the schema before.

Add @VFUC to CODEOWNERS