### PR TITLE
Fix bug where changes were detected even though no change happened

### DIFF
--- a/opensearch/resource_saved_objects.go
+++ b/opensearch/resource_saved_objects.go
@@ -177,6 +177,7 @@ func resourceSavedObjectRead(ctx context.Context, d *schema.ResourceData, m any)
 	for i := range resp.References {
 		a := make(map[string]any)
 		a["id"] = resp.References[i].ID
+		a["name"] = resp.References[i].Name
 		a["type"] = resp.References[i].Type
 		refs[i] = a
 	}


### PR DESCRIPTION
This fixes a bug where the name-field in references was ignored in the Opensearch-response. This caused terraform to always detect a change even though the fields were actually the same